### PR TITLE
Change vendor package name due to amzn was taken

### DIFF
--- a/php/config/templates/composer.mustache
+++ b/php/config/templates/composer.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "amzn/spapi-sdk",
+    "name": "amzn-spapi/sdk",
     "description": "Amazon Selling Partner APIs official client library for PHP.",
     "type": "library",
     "keywords": [


### PR DESCRIPTION
*Issue #, if available:*
https://issues.amazon.com/SAInquiries-5163
*Description of changes:*
Change vendor package name because amzn/ was taken by other service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
