### PR TITLE
Remove CP from release git hub action

### DIFF
--- a/.github/workflows/create-php-release.yml
+++ b/.github/workflows/create-php-release.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Debug file structure
         run: ls -R
 
-      - name: Copy composer.json to root
-        run: cp php/sdk/composer.json composer.json
-
       - name: Install jq
         run: sudo apt-get install -y jq
 


### PR DESCRIPTION
*Issue #, if available:*
https://issues.amazon.com/SAInquiries-5163
*Description of changes:*
Remove CP command from release git hub action, because symlink is already exist at the roots.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
