### PR TITLE
Change error handling on Notify Packagist

### DIFF
--- a/.github/workflows/create-php-release.yml
+++ b/.github/workflows/create-php-release.yml
@@ -36,7 +36,12 @@ jobs:
           -d '{ "repository": "https://github.com/amzn/selling-partner-api-sdk" }')
 
           cat response.json
-          if [ "$RESPONSE" -ne 200 ]; then exit 1; fi
+          STATUS=$(jq -r '.status' response.json)
+      
+          if [ "$STATUS" != "success" ]; then
+          echo "Error: Packagist update failed"
+          exit 1
+          fi
 
   tag_and_release:
     needs: release_php


### PR DESCRIPTION
*Issue #, if available:*
https://issues.amazon.com/SAInquiries-5163
*Description of changes:*
Change error handling to check with message on Notify Packagist, since Packagist is returning other than 200

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
