### PR TITLE
Fix: Making sure checking out latest by specifying depth

### DIFF
--- a/.github/workflows/test-java-sdk.yml
+++ b/.github/workflows/test-java-sdk.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test-php-sdk.yml
+++ b/.github/workflows/test-php-sdk.yml
@@ -10,7 +10,11 @@ jobs:
     name: test php sdk
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Just to be sure, test is running against latest by specifying depth, even though check out will be done latest by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
