### PR TITLE
Add overloaded constructor for ApiClient

### DIFF
--- a/java/sdk/src/main/java/software/amazon/spapi/ApiClient.java
+++ b/java/sdk/src/main/java/software/amazon/spapi/ApiClient.java
@@ -60,6 +60,19 @@ public class ApiClient {
         setUserAgent("amazon-selling-partner-api-sdk/" + (version != null ? version : "undefined") + "/Java");
     }
 
+    /*
+     * Overloaded Constructor for ApiClient
+     */
+    public ApiClient(OkHttpClient httpClient) {
+        this.httpClient = httpClient;
+
+        json = new JSON();
+
+        // Set default User-Agent.
+        String version = this.getClass().getPackage().getImplementationVersion();
+        setUserAgent("amazon-selling-partner-api-sdk/" + (version != null ? version : "undefined") + "/Java");
+    }
+
     /**
      * Get base path
      *


### PR DESCRIPTION
Add overloaded constructor for ApiClient to enable sharing of singleton OkHttpClient bean amongst multiple ApiClient objects.

*Issue #, if available:*

Issue # [482](https://github.com/amzn/selling-partner-api-sdk/issues/482)

*Description of changes:*

Added an overloaded constructor to software.amazon.spapi.ApiClient class that accepts OkHttpClient object. We will then be able to create a singleton bean of OkHttpClient and inject the same bean for every instance of ApiClient. This will reduce the memory bloat caused by multiple threads created by each new instance of OkHttpClient.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
