### PR TITLE
Add retry logic for authentication in PHP SDK

### DIFF
--- a/php/sdk/src/authandauth/LWAClient.php
+++ b/php/sdk/src/authandauth/LWAClient.php
@@ -61,32 +61,61 @@ class LWAClient
             'Content-Type' => 'application/json',
         ];
 
-        try {
-            $lwaRequest = new Request('POST', $this->endpoint, $contentHeader, $requestBody);
+        $maxRetries = 3;
+        $retryDelay = 100000; // 100ms in microseconds
+        $lastException = null;
 
-            $lwaResponse = $this->client->send($lwaRequest);
-            $responseJson = json_decode($lwaResponse->getBody(), true);
+        for ($attempt = 0; $attempt <= $maxRetries; $attempt++) {
+            try {
+                $lwaRequest = new Request('POST', $this->endpoint, $contentHeader, $requestBody);
 
-            if (!$responseJson['access_token'] || !$responseJson['expires_in']) {
-                throw new \RuntimeException('Response did not have required body');
+                $lwaResponse = $this->client->send($lwaRequest);
+                $responseJson = json_decode($lwaResponse->getBody(), true);
+
+                if (!$responseJson['access_token'] || !$responseJson['expires_in']) {
+                    throw new \RuntimeException('Response did not have required body');
+                }
+
+                $accessToken = $responseJson['access_token'];
+
+                if (null !== $this->lwaAccessTokenCache) {
+                    $timeToTokenExpire = (float) $responseJson['expires_in'];
+                    $this->lwaAccessTokenCache->set($requestBody, $accessToken, $timeToTokenExpire);
+                }
+
+                return $accessToken;
+            } catch (BadResponseException $e) {
+                $lastException = $e;
+                $statusCode = $e->getResponse() ? $e->getResponse()->getStatusCode() : 0;
+                
+                // Don't retry on 4xx errors except 429 (rate limit)
+                if ($statusCode >= 400 && $statusCode < 500 && $statusCode !== 429) {
+                    throw new \RuntimeException('Unsuccessful LWA token exchange', $e->getCode());
+                }
+                
+                // Retry on 5xx errors and 429
+                if ($attempt < $maxRetries) {
+                    usleep($retryDelay * (2 ** $attempt)); // Exponential backoff
+                    continue;
+                }
+            } catch (GuzzleException $e) {
+                $lastException = $e;
+                
+                // Retry on network errors
+                if ($attempt < $maxRetries) {
+                    usleep($retryDelay * (2 ** $attempt)); // Exponential backoff
+                    continue;
+                }
+            } catch (\Exception $e) {
+                throw new \RuntimeException('Error getting LWA Access Token', $e->getCode());
             }
-
-            $accessToken = $responseJson['access_token'];
-
-            if (null !== $this->lwaAccessTokenCache) {
-                $timeToTokenExpire = (float) $responseJson['expires_in'];
-                $this->lwaAccessTokenCache->set($requestBody, $accessToken, $timeToTokenExpire);
-            }
-        } catch (BadResponseException $e) {
-            // Catches 400 and 500 level error codes
-            throw new \RuntimeException('Unsuccessful LWA token exchange', $e->getCode());
-        } catch (\Exception $e) {
-            throw new \RuntimeException('Error getting LWA Access Token', $e->getCode());
-        } catch (GuzzleException $e) {
-            throw new \RuntimeException('Error getting LWA Access Token', $e->getCode());
         }
 
-        return $accessToken;
+        // If we've exhausted all retries
+        throw new \RuntimeException(
+            'Error getting LWA Access Token after ' . ($maxRetries + 1) . ' attempts',
+            $lastException ? $lastException->getCode() : 0
+        );
     }
 
     public function setClient(Client $client): void


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding exponential backoff retry on getting authentication to avoid PHP Test failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
